### PR TITLE
Update cpp_url_fetch to use the latest C++ SDK (v22.12.1-wasi-12)

### DIFF
--- a/cpp_url_fetch/Makefile
+++ b/cpp_url_fetch/Makefile
@@ -1,7 +1,7 @@
 # SDK versions that will be used for compilation
 # (CHANGE THE VERSION NUMBERS IF NEEDED)
 WASI_SDK_VERSION := 12.0
-EDJX_CPP_SDK_VERSION := v21.11.1-wasi-12
+EDJX_CPP_SDK_VERSION := v22.12.1-wasi-12
 
 # Root directories of WASI and EDJX C++ SDKs
 WASI_SDK_PATH := $(HOME)/edjx/wasi-sdk-$(WASI_SDK_VERSION)

--- a/cpp_url_fetch/src/lib.cpp
+++ b/cpp_url_fetch/src/lib.cpp
@@ -19,7 +19,7 @@ extern HttpResponse serverless(const HttpRequest & req);
 
 int main(void) {
     HttpRequest req;
-    HttpError err = HttpRequest::from_client(req, true);
+    HttpError err = HttpRequest::from_client(req);
     if (err != HttpError::Success) {
         error(edjx::error::to_string(err));
         HttpResponse().set_status(HTTP_STATUS_BAD_REQUEST).send();


### PR DESCRIPTION
Update the C++ version of the URL fetch function to use the latest EDJX C++ SDK.

The function used the `v21.11.1-wasi-12` version of the SDK. The SDK is installed manually, and the SDK installation instructions at https://docs.edjx.net install the latest SDK version (`v22.12.1-wasi-12`) unless a user specifies a different version. This PR updates the function to use the latest SDK version.

Fixes issue #2 